### PR TITLE
Adds prop content-id to fix broken menus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -871,9 +871,9 @@
       }
     },
     "@ionic/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-RXvKgl0Fbk9c2qILrVrhSsHOtWZXhp58exy9bsMWsaBTqqXKaN1iof9TyFqJ+YurEY56J0sRHT/TxgH9NOZhCQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-4.10.0.tgz",
+      "integrity": "sha512-uMlOVqd5+Ar3H1ubr5eOTI4mSoB2+BTiDG/onFUFnGOM6LE5Ui6eSgAYzkZm51euBJzMnGXHCtVh42DPive98w==",
       "requires": {
         "ionicons": "^4.6.3",
         "tslib": "^1.10.0"

--- a/src/views/Menu.vue
+++ b/src/views/Menu.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <Menu title="Reveal" side="start" type="reveal" menu-id="reveal" content-id="menu-page" />
-    <Menu title="Left" side="start" menu-id="first" />
-    <Menu title="Custom" side="start" menu-id="custom" class="my-custom-menu" color="tertiary" />
-    <Menu title="Push" side="end" type="push" />
+    <Menu title="Left" side="start" menu-id="first" content-id="menu-page" />
+    <Menu title="Custom" side="start" menu-id="custom" class="my-custom-menu" color="tertiary" content-id="menu-page" />
+    <Menu title="Push" side="end" type="push" content-id="menu-page" />
 
     <IonVuePage :title="'Menu'" id="menu-page">
       <ion-button @click="openLeftMenu">Open left menu</ion-button>


### PR DESCRIPTION
The `reveal` menu was the only one who specified a `content-id`. Unsure how this is used, they may need to be unique, if so let me know @michaeltintiuc  and I can add that change.

Closes #6